### PR TITLE
Add arbitrage bot core logic

### DIFF
--- a/core/arbitrage.py
+++ b/core/arbitrage.py
@@ -1,0 +1,51 @@
+import asyncio
+from typing import Dict, List
+
+from exchanges.factory import get_exchange
+from core.executor import Executor
+
+
+class ArbitrageBot:
+    """Simple arbitrage bot fetching prices and generating trade signals."""
+
+    def __init__(self, exchanges: List[str], symbol: str = "BTC/USDT", threshold: float = 0.5, interval: int = 5):
+        self.symbol = symbol
+        self.threshold = threshold
+        self.interval = interval
+        self.exchanges = {name: get_exchange(name) for name in exchanges}
+        self.executor = Executor()
+
+    async def fetch_prices(self) -> Dict[str, float]:
+        """Fetch ticker prices from all configured exchanges."""
+        prices: Dict[str, float] = {}
+        for name, ex in self.exchanges.items():
+            try:
+                ticker = await asyncio.to_thread(ex.fetch_ticker, self.symbol)
+                prices[name] = ticker["last"]
+            except Exception as exc:
+                print(f"[{name.upper()}] Failed to fetch price: {exc}")
+        return prices
+
+    def evaluate_spread(self, prices: Dict[str, float]):
+        """Compare spread across exchanges and generate trade signal."""
+        if len(prices) < 2:
+            return
+        buy_exchange = min(prices, key=prices.get)
+        sell_exchange = max(prices, key=prices.get)
+        buy_price = prices[buy_exchange]
+        sell_price = prices[sell_exchange]
+        spread = (sell_price - buy_price) / buy_price * 100
+        print(
+            f"Prices: {prices} | Best buy: {buy_exchange} {buy_price} | Best sell: {sell_exchange} {sell_price} | Spread: {spread:.2f}%"
+        )
+        if spread >= self.threshold:
+            print(f"Arbitrage opportunity detected: {spread:.2f}% spread")
+            self.executor.place_order(buy_exchange, "buy", self.symbol, 1, buy_price)
+            self.executor.place_order(sell_exchange, "sell", self.symbol, 1, sell_price)
+
+    async def run(self):
+        """Main loop fetching prices and checking for arbitrage."""
+        while True:
+            prices = await self.fetch_prices()
+            self.evaluate_spread(prices)
+            await asyncio.sleep(self.interval)

--- a/core/executor.py
+++ b/core/executor.py
@@ -1,0 +1,7 @@
+class Executor:
+    """Simulate order placement on an exchange."""
+
+    def place_order(self, exchange: str, side: str, symbol: str, amount: float, price: float) -> None:
+        print(
+            f"[SIMULATED ORDER] {side.upper()} {amount} {symbol} on {exchange.upper()} at {price}"
+        )


### PR DESCRIPTION
## Summary
- implement an `ArbitrageBot` that periodically fetches prices
- generate a trade signal when spread threshold is met
- simulate order placement via new `Executor`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68400efdea84833290cd62e2cae070c7