### PR TITLE
Add exchange time sync and logging

### DIFF
--- a/core/arbitrage.py
+++ b/core/arbitrage.py
@@ -1,0 +1,59 @@
+import asyncio
+import logging
+from typing import Dict, List
+
+from exchanges.factory import get_exchange
+from core.executor import Executor
+
+
+class ArbitrageBot:
+    """Simple arbitrage bot fetching prices and generating trade signals."""
+
+    def __init__(self, exchanges: List[str], symbol: str = "BTC/USDT", threshold: float = 0.5, interval: int = 5):
+        self.symbol = symbol
+        self.threshold = threshold
+        self.interval = interval
+        self.exchanges = {name: get_exchange(name) for name in exchanges}
+        self.executor = Executor()
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def fetch_prices(self) -> Dict[str, float]:
+        """Fetch ticker prices from all configured exchanges."""
+        prices: Dict[str, float] = {}
+        for name, ex in self.exchanges.items():
+            try:
+                ticker = await asyncio.to_thread(ex.fetch_ticker, self.symbol)
+                prices[name] = ticker["last"]
+            except Exception as exc:
+                self.logger.warning("[%s] Failed to fetch price: %s", name.upper(), exc)
+        return prices
+
+    def evaluate_spread(self, prices: Dict[str, float]):
+        """Compare spread across exchanges and generate trade signal."""
+        if len(prices) < 2:
+            return
+        buy_exchange = min(prices, key=prices.get)
+        sell_exchange = max(prices, key=prices.get)
+        buy_price = prices[buy_exchange]
+        sell_price = prices[sell_exchange]
+        spread = (sell_price - buy_price) / buy_price * 100
+        self.logger.info(
+            "Prices: %s | Best buy: %s %s | Best sell: %s %s | Spread: %.2f%%",
+            prices,
+            buy_exchange,
+            buy_price,
+            sell_exchange,
+            sell_price,
+            spread,
+        )
+        if spread >= self.threshold:
+            self.logger.info("Arbitrage opportunity detected: %.2f%% spread", spread)
+            self.executor.place_order(buy_exchange, "buy", self.symbol, 1, buy_price)
+            self.executor.place_order(sell_exchange, "sell", self.symbol, 1, sell_price)
+
+    async def run(self):
+        """Main loop fetching prices and checking for arbitrage."""
+        while True:
+            prices = await self.fetch_prices()
+            self.evaluate_spread(prices)
+            await asyncio.sleep(self.interval)

--- a/core/executor.py
+++ b/core/executor.py
@@ -1,0 +1,18 @@
+import logging
+
+
+class Executor:
+    """Simulate order placement on an exchange."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def place_order(self, exchange: str, side: str, symbol: str, amount: float, price: float) -> None:
+        self.logger.info(
+            "[SIMULATED ORDER] %s %.4f %s on %s at %s",
+            side.upper(),
+            amount,
+            symbol,
+            exchange.upper(),
+            price,
+        )

--- a/exchanges/factory.py
+++ b/exchanges/factory.py
@@ -1,8 +1,10 @@
 import ccxt
+import logging
 from config import EXCHANGE_CONFIG
 
 
 def get_exchange(name: str):
+    """Instantiate a ccxt exchange with sane defaults."""
     name = name.lower()
     if name not in EXCHANGE_CONFIG:
         raise ValueError(f"Exchange config not found: {name}")
@@ -10,8 +12,16 @@ def get_exchange(name: str):
     exchange_class = getattr(ccxt, name)
     config = EXCHANGE_CONFIG[name]
 
-    return exchange_class({
+    exchange = exchange_class({
         'apiKey': config['apiKey'],
         'secret': config['secret'],
         'enableRateLimit': True,
+        'options': {'adjustForTimeDifference': True},
     })
+
+    try:
+        exchange.load_time_difference()
+    except Exception as exc:
+        logging.warning(f"[{name.upper()}] Could not sync time: {exc}")
+
+    return exchange


### PR DESCRIPTION
## Summary
- handle clock skew errors by syncing time in `get_exchange`
- log exchange failures and trade actions using the standard logger

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68400efdea84833290cd62e2cae070c7